### PR TITLE
カテゴリ別表示の実装 #39

### DIFF
--- a/backend/app/Http/Controllers/PostController.php
+++ b/backend/app/Http/Controllers/PostController.php
@@ -3,7 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Models\Post;
-use Illuminate\Http\UploadedFile;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use App\Http\Requests\PhotoPostRequest;
 use Illuminate\Support\Facades\Storage;
@@ -44,21 +44,19 @@ class PostController extends Controller
 
     // 投稿一覧を取得
     public function getAllPosts() {
-        $data = array();
-        $posts = Post::with('user', 'category')->orderBy('updated_at','desc')->paginate(9);
+        $posts = Post::with('user', 'category')
+            ->orderBy('updated_at','desc')
+            ->paginate(9);
 
-        // 必要部分のみ抜き出してresponse
-        foreach ($posts as $post) {
-            $json = [
-                'id' => $post->id,
-                'user_name' => $post->user->name,
-                'file_path' => $post->file_path,
-                'category' => $post->category->name,
-                'updated_at' => $post->updated_at->format('Y-m-d H:i'),
-                'text' => $post->text
-            ];
-            array_push($data, $json);
-        };
+        return response()->json($posts);
+    }
+
+    // カテゴリ別一覧の取得
+    public function getPostsWithCategory($id) {
+        $posts = Post::with('user', 'category')
+            ->where('category_id', $id)
+            ->orderBy('updated_at','desc')
+            ->paginate(9);
 
         return response()->json($posts);
     }

--- a/backend/app/Models/Category.php
+++ b/backend/app/Models/Category.php
@@ -13,6 +13,11 @@ class Category extends Model
         'name'
     ];
 
+    protected $hidden = [
+        'created_at',
+        'updated_at'
+    ];
+
     /**
      * リレーションの設定
      */

--- a/backend/app/Models/Post.php
+++ b/backend/app/Models/Post.php
@@ -21,6 +21,11 @@ class Post extends Model
         return  $date->format('Y-m-d H:i');
     }
 
+    // レスポンスの際に不必要なカラムを除く
+    protected $hidden = [
+        'created_at'
+    ];
+
     /**
      * リレーションの設定
      *

--- a/backend/app/Models/User.php
+++ b/backend/app/Models/User.php
@@ -32,6 +32,9 @@ class User extends Authenticatable implements JWTSubject
     protected $hidden = [
         'password',
         'remember_token',
+        'email_verified_at',
+        'created_at',
+        'updated_at'
     ];
 
     /**

--- a/backend/config/jwt.php
+++ b/backend/config/jwt.php
@@ -235,7 +235,7 @@ return [
     |
     */
 
-    'blacklist_grace_period' => env('JWT_BLACKLIST_GRACE_PERIOD', 0),
+    'blacklist_grace_period' => env('JWT_BLACKLIST_GRACE_PERIOD', 10),
 
     /*
     |--------------------------------------------------------------------------

--- a/backend/public/js/app.js
+++ b/backend/public/js/app.js
@@ -19585,7 +19585,10 @@ var PostCard = function PostCard(props) {
         variant: "outlined",
         size: "small",
         icon: /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_2__.jsx)(_material_ui_icons_FilterHdr__WEBPACK_IMPORTED_MODULE_7__.default, {}),
-        label: props.category
+        label: props.category,
+        onClick: function onClick() {
+          return props.chipClick();
+        }
       })]
     }), /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_2__.jsx)(_material_ui_core__WEBPACK_IMPORTED_MODULE_8__.default, {
       className: classes.content,
@@ -20974,7 +20977,9 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var react__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! react */ "./node_modules/react/index.js");
 /* harmony import */ var _components_Posts__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ../components/Posts */ "./resources/js/components/Posts/index.js");
 /* harmony import */ var _components_UIKit__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! ../components/UIKit */ "./resources/js/components/UIKit/index.js");
-/* harmony import */ var react_jsx_runtime__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(/*! react/jsx-runtime */ "./node_modules/react/jsx-runtime.js");
+/* harmony import */ var react_redux__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(/*! react-redux */ "./node_modules/react-redux/es/index.js");
+/* harmony import */ var connected_react_router__WEBPACK_IMPORTED_MODULE_6__ = __webpack_require__(/*! connected-react-router */ "./node_modules/connected-react-router/esm/actions.js");
+/* harmony import */ var react_jsx_runtime__WEBPACK_IMPORTED_MODULE_5__ = __webpack_require__(/*! react/jsx-runtime */ "./node_modules/react/jsx-runtime.js");
 
 
 function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } }
@@ -20999,6 +21004,8 @@ function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
 
 
 
+
+
 var PostList = function PostList() {
   var _useState = (0,react__WEBPACK_IMPORTED_MODULE_1__.useState)([]),
       _useState2 = _slicedToArray(_useState, 2),
@@ -21013,62 +21020,88 @@ var PostList = function PostList() {
       totalPage = _useState6[0],
       setTotalPage = _useState6[1];
 
-  console.log(page, totalPage); // 初期値のセット
+  var dispatch = (0,react_redux__WEBPACK_IMPORTED_MODULE_4__.useDispatch)();
+  var selector = (0,react_redux__WEBPACK_IMPORTED_MODULE_4__.useSelector)(function (state) {
+    return state;
+  });
+  var query = selector.router.location.search; // 取得したクエリが<?category=>の形と一致するか確認し、category_idを取得
 
-  (0,react__WEBPACK_IMPORTED_MODULE_1__.useEffect)(function () {
-    var getPostList = /*#__PURE__*/function () {
-      var _ref = _asyncToGenerator( /*#__PURE__*/_babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0___default().mark(function _callee() {
-        var url;
-        return _babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0___default().wrap(function _callee$(_context) {
-          while (1) {
-            switch (_context.prev = _context.next) {
-              case 0:
-                url = 'http://localhost:30080/api/v1/posts/';
-                _context.next = 3;
-                return fetch(url).then(function (response) {
-                  return response.json();
-                }).then(function (responseJson) {
-                  setPostList(responseJson.data);
-                  setTotalPage(responseJson.last_page);
-                })["catch"](function (error) {
-                  return console.error(error);
-                });
+  var category = /^\?category=/.test(query) ? query.split('?category=')[1] : '';
+  var getPostList = (0,react__WEBPACK_IMPORTED_MODULE_1__.useCallback)( /*#__PURE__*/function () {
+    var _ref = _asyncToGenerator( /*#__PURE__*/_babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0___default().mark(function _callee(page) {
+      var url, _url;
 
-              case 3:
-              case "end":
-                return _context.stop();
-            }
+      return _babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0___default().wrap(function _callee$(_context) {
+        while (1) {
+          switch (_context.prev = _context.next) {
+            case 0:
+              if (category) {
+                _context.next = 7;
+                break;
+              }
+
+              setPage(page);
+              url = 'http://localhost:30080/api/v1/posts?page=' + page;
+              _context.next = 5;
+              return fetch(url).then(function (response) {
+                return response.json();
+              }).then(function (responseJson) {
+                setPostList(responseJson.data);
+                setTotalPage(responseJson.last_page);
+              })["catch"](function (error) {
+                return console.error(error);
+              });
+
+            case 5:
+              _context.next = 11;
+              break;
+
+            case 7:
+              setPage(page);
+              _url = 'http://localhost:30080/api/v1/categories/' + category + '?page=' + page;
+              _context.next = 11;
+              return fetch(_url).then(function (response) {
+                return response.json();
+              }).then(function (responseJson) {
+                setPostList(responseJson.data);
+                setTotalPage(responseJson.last_page);
+              })["catch"](function (error) {
+                return console.error(error);
+              });
+
+            case 11:
+            case "end":
+              return _context.stop();
           }
-        }, _callee);
-      }));
+        }
+      }, _callee);
+    }));
 
-      return function getPostList() {
-        return _ref.apply(this, arguments);
-      };
-    }();
-
-    getPostList();
-  }, []); // ページネーション実行の関数
-
-  var pageSwitched = (0,react__WEBPACK_IMPORTED_MODULE_1__.useCallback)( /*#__PURE__*/function () {
-    var _ref2 = _asyncToGenerator( /*#__PURE__*/_babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0___default().mark(function _callee2(page) {
+    return function (_x) {
+      return _ref.apply(this, arguments);
+    };
+  }(), [getPostList]);
+  var chipClickHandler = (0,react__WEBPACK_IMPORTED_MODULE_1__.useCallback)( /*#__PURE__*/function () {
+    var _ref2 = _asyncToGenerator( /*#__PURE__*/_babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0___default().mark(function _callee2(id) {
       var url;
       return _babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0___default().wrap(function _callee2$(_context2) {
         while (1) {
           switch (_context2.prev = _context2.next) {
             case 0:
+              dispatch((0,connected_react_router__WEBPACK_IMPORTED_MODULE_6__.push)('/?category=' + id));
               setPage(page);
-              url = 'http://localhost:30080/api/v1/posts?page=' + page;
-              _context2.next = 4;
+              url = 'http://localhost:30080/api/v1/categories/' + id + '?page=' + page;
+              _context2.next = 5;
               return fetch(url).then(function (response) {
                 return response.json();
               }).then(function (responseJson) {
                 setPostList(responseJson.data);
+                setTotalPage(responseJson.last_page);
               })["catch"](function (error) {
                 return console.error(error);
               });
 
-            case 4:
+            case 5:
             case "end":
               return _context2.stop();
           }
@@ -21076,28 +21109,34 @@ var PostList = function PostList() {
       }, _callee2);
     }));
 
-    return function (_x) {
+    return function (_x2) {
       return _ref2.apply(this, arguments);
     };
-  }(), [pageSwitched]);
-  console.log(postList);
-  return /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_4__.jsxs)("section", {
+  }(), [chipClickHandler]); // 初期値のセット
+
+  (0,react__WEBPACK_IMPORTED_MODULE_1__.useEffect)(function () {
+    getPostList(page);
+  }, []);
+  return /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_5__.jsxs)("section", {
     className: "large-section",
-    children: [/*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_4__.jsx)("div", {
+    children: [/*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_5__.jsx)("div", {
       className: "grid-row",
       children: postList.map(function (post) {
-        return /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_4__.jsx)(_components_Posts__WEBPACK_IMPORTED_MODULE_2__.PostCard, {
+        return /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_5__.jsx)(_components_Posts__WEBPACK_IMPORTED_MODULE_2__.PostCard, {
           image: post.file_path,
           text: post.text,
           category: post.category.name,
           name: post.user.name,
-          date: post.updated_at
+          date: post.updated_at,
+          chipClick: function chipClick() {
+            return chipClickHandler(post.category_id);
+          }
         }, post.id);
       })
-    }), /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_4__.jsx)(_components_UIKit__WEBPACK_IMPORTED_MODULE_3__.Pagination, {
+    }), /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_5__.jsx)(_components_UIKit__WEBPACK_IMPORTED_MODULE_3__.Pagination, {
       count: totalPage,
       disabled: false,
-      onChange: pageSwitched,
+      onChange: getPostList,
       page: page
     })]
   });

--- a/backend/public/mix-manifest.json
+++ b/backend/public/mix-manifest.json
@@ -1,4 +1,4 @@
 {
-    "/js/app.js": "/js/app.js?id=0c47bdec150285a5e706",
+    "/js/app.js": "/js/app.js?id=027f47c282e2e85b6e7c",
     "/css/app.css": "/css/app.css?id=a86101e4175555bfc46c"
 }

--- a/backend/resources/js/components/Posts/PostCard.jsx
+++ b/backend/resources/js/components/Posts/PostCard.jsx
@@ -59,6 +59,7 @@ const PostCard = (props) => {
                     size="small"
                     icon={<FilterHdrIcon />}
                     label={props.category}
+                    onClick={() => props.chipClick()}
                 />
             </div>
             <CardContent className={classes.content}>

--- a/backend/resources/js/templates/PostList.jsx
+++ b/backend/resources/js/templates/PostList.jsx
@@ -1,18 +1,52 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { PostCard } from '../components/Posts';
 import { Pagination } from '../components/UIKit';
+import { useDispatch, useSelector } from 'react-redux';
+import { push } from 'connected-react-router';
 
 const PostList = () => {
     const [postList, setPostList] = useState([]),
         [page, setPage] = useState(1),
         [totalPage, setTotalPage] = useState(0);
 
-    console.log(page, totalPage);
+    const dispatch = useDispatch();
+    const selector = useSelector((state) => state);
+    const query = selector.router.location.search;
+    // 取得したクエリが<?category=>の形と一致するか確認し、category_idを取得
+    const category = /^\?category=/.test(query) ? query.split('?category=')[1] : '';
 
-    // 初期値のセット
-    useEffect(() => {
-        const getPostList = async () => {
-            const url = 'http://localhost:30080/api/v1/posts/';
+    const getPostList = useCallback(
+        async (page) => {
+            if (!category) {
+                setPage(page);
+                const url = 'http://localhost:30080/api/v1/posts?page=' + page;
+                await fetch(url)
+                    .then((response) => response.json())
+                    .then((responseJson) => {
+                        setPostList(responseJson.data);
+                        setTotalPage(responseJson.last_page);
+                    })
+                    .catch((error) => console.error(error));
+            } else {
+                setPage(page);
+                const url = 'http://localhost:30080/api/v1/categories/' + category + '?page=' + page;
+                await fetch(url)
+                    .then((response) => response.json())
+                    .then((responseJson) => {
+                        setPostList(responseJson.data);
+                        setTotalPage(responseJson.last_page);
+                    })
+                    .catch((error) => console.error(error));
+            }
+        },
+        [getPostList]
+    );
+
+    const chipClickHandler = useCallback(
+        async (id) => {
+            dispatch(push('/?category=' + id));
+            setPage(page);
+            const url = 'http://localhost:30080/api/v1/categories/' + id + '?page=' + page;
             await fetch(url)
                 .then((response) => response.json())
                 .then((responseJson) => {
@@ -20,26 +54,14 @@ const PostList = () => {
                     setTotalPage(responseJson.last_page);
                 })
                 .catch((error) => console.error(error));
-        };
-        getPostList();
-    }, []);
-
-    // ページネーション実行の関数
-    const pageSwitched = useCallback(
-        async (page) => {
-            setPage(page);
-            const url = 'http://localhost:30080/api/v1/posts?page=' + page;
-            await fetch(url)
-                .then((response) => response.json())
-                .then((responseJson) => {
-                    setPostList(responseJson.data);
-                })
-                .catch((error) => console.error(error));
         },
-        [pageSwitched]
+        [chipClickHandler]
     );
 
-    console.log(postList);
+    // 初期値のセット
+    useEffect(() => {
+        getPostList(page);
+    }, []);
 
     return (
         <section className="large-section">
@@ -52,10 +74,11 @@ const PostList = () => {
                         category={post.category.name}
                         name={post.user.name}
                         date={post.updated_at}
+                        chipClick={() => chipClickHandler(post.category_id)}
                     />
                 ))}
             </div>
-            <Pagination count={totalPage} disabled={false} onChange={pageSwitched} page={page} />
+            <Pagination count={totalPage} disabled={false} onChange={getPostList} page={page} />
         </section>
     );
 };

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -35,8 +35,12 @@ Route::post('/v1/refresh', [AuthController::class, 'refresh'])->name('refresh');
 //　カテゴリーの取得
 Route::get('/v1/categories', [CategoryController::class, 'getAllCategories'])->name('getAllCategories');
 
-//投稿一覧の取得
+//　投稿一覧の取得
 Route::get('/v1/posts', [PostController::class, 'getAllPosts'])->name('getAllPosts');
+
+//　カテゴリー別投稿一覧の取得
+Route::get('/v1/categories/{id}', [PostController::class, 'getPostsWithCategory'])->name('getPostsWithCategory');
+
 
 Route::middleware(['auth:api'])->group(function () {
     // 認証ユーザーを返却する


### PR DESCRIPTION
PostControllerにカテゴリ別投稿一覧取得のAPIを作成
Homeにて、カテゴリのクエリ文字列がURLに存在する場合、各カテゴリの記事を表示するよう実装